### PR TITLE
Fix handing of attributes nodes in NodeNavigator

### DIFF
--- a/html/query.go
+++ b/html/query.go
@@ -216,6 +216,9 @@ func (h *NodeNavigator) MoveToNextAttribute() bool {
 }
 
 func (h *NodeNavigator) MoveToChild() bool {
+	if h.attr != -1 {
+		return false
+	}
 	if node := h.curr.FirstChild; node != nil {
 		h.curr = node
 		return true
@@ -224,7 +227,7 @@ func (h *NodeNavigator) MoveToChild() bool {
 }
 
 func (h *NodeNavigator) MoveToFirst() bool {
-	if h.curr.PrevSibling == nil {
+	if h.attr != -1 || h.curr.PrevSibling == nil {
 		return false
 	}
 	for {
@@ -242,6 +245,9 @@ func (h *NodeNavigator) String() string {
 }
 
 func (h *NodeNavigator) MoveToNext() bool {
+	if h.attr != -1 {
+		return false
+	}
 	if node := h.curr.NextSibling; node != nil {
 		h.curr = node
 		return true
@@ -250,6 +256,9 @@ func (h *NodeNavigator) MoveToNext() bool {
 }
 
 func (h *NodeNavigator) MoveToPrevious() bool {
+	if h.attr != -1 {
+		return false
+	}
 	if node := h.curr.PrevSibling; node != nil {
 		h.curr = node
 		return true

--- a/html/query_test.go
+++ b/html/query_test.go
@@ -9,7 +9,36 @@ import (
 	"golang.org/x/net/html"
 )
 
-var doc = loadHTML()
+const htmlSample = `<!DOCTYPE html><html lang="en-US">
+<head>
+<title>Hello,World!</title>
+</head>
+<body>
+<div class="container">
+<header>
+	<!-- Logo -->
+   <h1>City Gallery</h1>
+</header>  
+<nav>
+  <ul>
+    <li><a href="#">London</a></li>
+    <li><a href="#">Paris</a></li>
+    <li><a href="#">Tokyo</a></li>
+  </ul>
+</nav>
+<article>
+  <h1>London</h1>
+  <img src="pic_mountain.jpg" alt="Mountain View" style="width:304px;height:228px;">
+  <p>London is the capital city of England. It is the most populous city in the  United Kingdom, with a metropolitan area of over 13 million inhabitants.</p>
+  <p>Standing on the River Thames, London has been a major settlement for two millennia, its history going back to its founding by the Romans, who named it Londinium.</p>
+</article>
+<footer>Copyright &copy; W3Schools.com</footer>
+</div>
+</body>
+</html>
+`
+
+var doc = loadHTML(htmlSample)
 
 func TestHttpLoad(t *testing.T) {
 	doc, err := LoadURL("http://www.bing.com")
@@ -43,6 +72,7 @@ func TestNavigator(t *testing.T) {
 		t.Fatal("node not move to lang attribute")
 	}
 
+	nav.MoveToParent()
 	nav.MoveToFirst() // <!DOCTYPE html>
 	if nav.curr.Type != html.DoctypeNode {
 		t.Fatalf("expected node type is DoctypeNode,but got %d", nav.curr.Type)
@@ -71,35 +101,16 @@ func TestXPath(t *testing.T) {
 	}
 }
 
-func loadHTML() *html.Node {
-	var str = `<!DOCTYPE html><html lang="en-US">
-<head>
-<title>Hello,World!</title>
-</head>
-<body>
-<div class="container">
-<header>
-	<!-- Logo -->
-   <h1>City Gallery</h1>
-</header>  
-<nav>
-  <ul>
-    <li><a href="#">London</a></li>
-    <li><a href="#">Paris</a></li>
-    <li><a href="#">Tokyo</a></li>
-  </ul>
-</nav>
-<article>
-  <h1>London</h1>
-  <img src="pic_mountain.jpg" alt="Mountain View" style="width:304px;height:228px;">
-  <p>London is the capital city of England. It is the most populous city in the  United Kingdom, with a metropolitan area of over 13 million inhabitants.</p>
-  <p>Standing on the River Thames, London has been a major settlement for two millennia, its history going back to its founding by the Romans, who named it Londinium.</p>
-</article>
-<footer>Copyright &copy; W3Schools.com</footer>
-</div>
-</body>
-</html>
-`
+func TestXPathCdUp(t *testing.T) {
+	doc := loadHTML(`<html><b attr="1"></b></html>`)
+	node := FindOne(doc, "//b/@attr/..")
+	t.Logf("node = %#v", node)
+	if node == nil || node.Data != "b" {
+		t.Fatal("//b/@id/.. != <b></b>")
+	}
+}
+
+func loadHTML(str string) *html.Node {
 	node, err := Parse(strings.NewReader(str))
 	if err != nil {
 		panic(err)

--- a/xml/query.go
+++ b/xml/query.go
@@ -168,6 +168,9 @@ func (x *NodeNavigator) MoveToNextAttribute() bool {
 }
 
 func (x *NodeNavigator) MoveToChild() bool {
+	if x.attr != -1 {
+		return false
+	}
 	if node := x.curr.FirstChild; node != nil {
 		x.curr = node
 		return true
@@ -176,7 +179,7 @@ func (x *NodeNavigator) MoveToChild() bool {
 }
 
 func (x *NodeNavigator) MoveToFirst() bool {
-	if x.curr.PrevSibling == nil {
+	if x.attr != -1 || x.curr.PrevSibling == nil {
 		return false
 	}
 	for {
@@ -194,6 +197,9 @@ func (x *NodeNavigator) String() string {
 }
 
 func (x *NodeNavigator) MoveToNext() bool {
+	if x.attr != -1 {
+		return false
+	}
 	if node := x.curr.NextSibling; node != nil {
 		x.curr = node
 		return true
@@ -202,6 +208,9 @@ func (x *NodeNavigator) MoveToNext() bool {
 }
 
 func (x *NodeNavigator) MoveToPrevious() bool {
+	if x.attr != -1 {
+		return false
+	}
 	if node := x.curr.PrevSibling; node != nil {
 		x.curr = node
 		return true


### PR DESCRIPTION
I believe this fixes #16 for XML. It also add a test for this case.

Attribute nodes were not handled correctly. Many NodeNavigator functions assumed
that they were on the parent element node instead of the attribute node. See
section 5 of XPATH 1.0 recommendation.

<https://www.w3.org/TR/xpath/#attribute-nodes>