### PR TITLE
Values not escaped when using <node>.OutputXML(true)

### DIFF
--- a/xml/node.go
+++ b/xml/node.go
@@ -66,7 +66,7 @@ func (n *Node) InnerText() string {
 
 func outputXML(buf *bytes.Buffer, n *Node) {
 	if n.Type == TextNode || n.Type == CommentNode {
-		buf.WriteString(strings.TrimSpace(n.Data))
+		xml.EscapeText(buf, []byte(strings.TrimSpace(n.Data)))
 		return
 	}
 	if n.Type == DeclarationNode {

--- a/xml/node_test.go
+++ b/xml/node_test.go
@@ -275,5 +275,16 @@ func TestSelectElement(t *testing.T) {
 }
 
 func TestEscapeOutputValue(t *testing.T) {
-	data := `<AAA><*></AAA>`
+	data := `<AAA>&lt;*&gt;</AAA>`
+
+	root, err := Parse(strings.NewReader(data))
+	if err != nil {
+		t.Error(err)
+	}
+
+	escapedInnerText := root.OutputXML(true)
+	if !strings.Contains(escapedInnerText, "&lt;*&gt;") {
+		t.Fatal("Inner Text has not been escaped")
+	}
+
 }

--- a/xml/node_test.go
+++ b/xml/node_test.go
@@ -273,3 +273,7 @@ func TestSelectElement(t *testing.T) {
 		t.Fatalf("len(ns)!=2")
 	}
 }
+
+func TestEscapeOutputValue(t *testing.T) {
+	data := `<AAA><*></AAA>`
+}


### PR DESCRIPTION
When XML with escaped characters such as `&lt;` is loaded it will be transformed into its un-escaped version. Then when `OutputXML(true)` is used the inner text values are returned in the un-escaped version.
This PR will add escaping to the inner text of nodes for the output of `OutputXML(true)`